### PR TITLE
use group substitution in etchosts.yml

### DIFF
--- a/provisioning/etchosts.yml
+++ b/provisioning/etchosts.yml
@@ -7,4 +7,5 @@
                   regexp='.*{{ item }}$' line="{{ hostvars[item].ansible_default_ipv4.address }} {{item}}"
                   state=present
       when: hostvars[item].ansible_default_ipv4.address is defined
-      with_items: groups['all'] 
+      with_items:
+        - "{{ groups['all'] }}"


### PR DESCRIPTION
When running on F26 with ansible 2.3.2.0 the etchosts.yml task "Build hosts file" fails indicating that groups['all'] is undefined.  By placing it in a list on the next line in a template, the playbook task will pass on all hosts.
